### PR TITLE
feat: 添加文本消息 @ 成员功能

### DIFF
--- a/nodes/WeCom/resources/pushMessage/execute.ts
+++ b/nodes/WeCom/resources/pushMessage/execute.ts
@@ -18,12 +18,32 @@ export async function executePushMessage(
 			if (operation === 'sendText') {
 				// 发送文本消息
 				const content = this.getNodeParameter('content', i) as string;
+				const mentionedList = this.getNodeParameter('mentionedList', i, '') as string;
+				const mentionedMobileList = this.getNodeParameter('mentionedMobileList', i, '') as string;
+
+				const textBody: IDataObject = {
+					content,
+				};
+
+				// 处理 mentioned_list
+				if (mentionedList.trim()) {
+					const mentioned = mentionedList.split(',').map(item => item.trim()).filter(item => item);
+					if (mentioned.length > 0) {
+						textBody.mentioned_list = mentioned;
+					}
+				}
+
+				// 处理 mentioned_mobile_list
+				if (mentionedMobileList.trim()) {
+					const mentionedMobile = mentionedMobileList.split(',').map(item => item.trim()).filter(item => item);
+					if (mentionedMobile.length > 0) {
+						textBody.mentioned_mobile_list = mentionedMobile;
+					}
+				}
 
 				body = {
 					msgtype: 'text',
-					text: {
-						content,
-					},
+					text: textBody,
 				};
 
 			} else if (operation === 'sendMarkdown') {

--- a/nodes/WeCom/resources/pushMessage/sendText.ts
+++ b/nodes/WeCom/resources/pushMessage/sendText.ts
@@ -22,5 +22,29 @@ export const sendTextDescription: INodeProperties[] = [
 		description: '文本消息内容，最长不超过2048个字节。<a href="https://developer.work.weixin.qq.com/document/path/99110#%E6%96%87%E6%9C%AC%E7%B1%BB%E5%9E%8B" target="_blank">官方文档</a>',
 		hint: '支持换行符，支持通过\\n换行',
 	},
+	{
+		displayName: '@ 成员（UserID）',
+		name: 'mentionedList',
+		type: 'string',
+		displayOptions: {
+			show: showOnlyForSendText,
+		},
+		default: '',
+		placeholder: 'wangqing,zhangsan 或 @all',
+		description: 'userid 列表，提醒群中的指定成员。多个成员用逗号分隔，@all 表示提醒所有人。<a href="https://developer.work.weixin.qq.com/document/path/99110#%E6%96%87%E6%9C%AC%E7%B1%BB%E5%9E%8B" target="_blank">官方文档</a>',
+		hint: '示例：wangqing,zhangsan 或 @all',
+	},
+	{
+		displayName: '@ 成员（手机号）',
+		name: 'mentionedMobileList',
+		type: 'string',
+		displayOptions: {
+			show: showOnlyForSendText,
+		},
+		default: '',
+		placeholder: '13800001111,13900002222 或 @all',
+		description: '手机号列表，提醒手机号对应的群成员。多个手机号用逗号分隔，@all 表示提醒所有人。<a href="https://developer.work.weixin.qq.com/document/path/99110#%E6%96%87%E6%9C%AC%E7%B1%BB%E5%9E%8B" target="_blank">官方文档</a>',
+		hint: '示例：13800001111,13900002222 或 @all',
+	},
 ];
 


### PR DESCRIPTION
为企业微信文本消息推送添加 mentioned_list 和 mentioned_mobile_list 支持， 允许通过 userid 或手机号 @ 群成员，支持 @all 提醒所有人。

## 功能截图
<img width="737" height="667" alt="image" src="https://github.com/user-attachments/assets/c22fff79-15d2-409c-ae67-17db58562269" />


@funcodingdev 帮忙手动合并下，流水线过不去。